### PR TITLE
in st_split st_combine blade if length > 1

### DIFF
--- a/R/split.R
+++ b/R/split.R
@@ -19,9 +19,9 @@ st_split.sfg = function(x, y) {
 
 #' @export
 st_split.sfc = function(x, y) {
-    stopifnot(length(y) == 1)
+    if (length(y) > 1) y = sf::st_combine(y)
 	if (inherits(x, "sfc_POLYGON") || inherits(x, "sfc_MULTIPOLYGON"))
-    	stopifnot(inherits(y, "sfc_LINESTRING"))
+    	stopifnot(inherits(y, "sfc_LINESTRING") || inherits(y, "sfc_MULTILINESTRING"))
 	else
 		stopifnot(inherits(x, "sfc_LINESTRING") || inherits(x, "sfc_MULTILINESTRING"))
     st_sfc(CPL_split(x, st_geometry(y)), crs = st_crs(x))


### PR DESCRIPTION
This PR addresses a slight discrepancy between documentation and code. In the documentation for `st_split` it is noted that 

> if y contains more than one feature geometry, the geometries are st_combined

though this didn't happen in the code. It simply threw an error via `stopifnot(length(y) == 1)`. Therefore I have adjusted the code to accommodate what the documentation states.

The issue was originally raised in [this SO question](https://stackoverflow.com/questions/55519152/split-line-by-multiple-points-using-sf-package/55557452)
