### PR TITLE
Windows: update proj/geos to match sf

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -83,20 +83,21 @@ OBJECTS_RCPP= \
 
 OBJECTS= $(OBJECTS_LIBLWGEOM) $(OBJECTS_RCPP)
 
-VERSION = 3.0.4
+VERSION = 3.2.1
 RWINLIB = ../windows/gdal3-$(VERSION)
 TARGET = lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH)
 
 PKG_CPPFLAGS = \
 	-I./liblwgeom \
-	-I$(RWINLIB)/include/geos-3.8.0 \
-	-I$(RWINLIB)/include/proj-6.3.1 \
+	-I$(RWINLIB)/include/geos-3.9.0 \
+	-I$(RWINLIB)/include/proj-7.2.1 \
 	-DUSE_PROJ_H
 
 PKG_LIBS = \
 	-L$(RWINLIB)/$(TARGET) \
 	-L$(RWINLIB)/lib$(R_ARCH) \
-	-lproj -lgeos_c -lgeos -ljson-c -lexpat -lxml2 -liconv -lsqlite3
+	-lproj -lgeos_c -lgeos -ljson-c -lexpat -lxml2 -liconv -lsqlite3 \
+	-ltiff -ljpeg -lcurl -lssh2 -lz -lssl -lcrypto -lgdi32 -lws2_32 -lcrypt32 -lwldap32
 
 all: clean winlibs
 


### PR DESCRIPTION
Use the same rwinlib binaries as we do for sf and rgdal. 