### PR TITLE
preallocate CharacterVector in st_astext to improve performance on large data

### DIFF
--- a/src/lwgeom.cpp
+++ b/src/lwgeom.cpp
@@ -326,10 +326,10 @@ Rcpp::NumericMatrix CPL_endpoint(Rcpp::List sfc) {
 Rcpp::CharacterVector CPL_sfc_to_wkt(Rcpp::List sfc, Rcpp::IntegerVector precision) {
 
   std::vector<LWGEOM *> lwgeom_cw = lwgeom_from_sfc(sfc);
-  Rcpp::CharacterVector out;
+  Rcpp::CharacterVector out(lwgeom_cw.size());
   for (size_t i = 0; i < lwgeom_cw.size(); i++) {
 	char *wkt = lwgeom_to_wkt(lwgeom_cw[i], WKT_EXTENDED, precision[0], NULL);
-    out.push_back(wkt);
+        out[i] = wkt;
 	free(wkt);
   }
   return out;


### PR DESCRIPTION
`st_astext` is currently growing Rcpp `CharacterVectors` which seems to incur quite a larger time and memory penalty on larger datasets.

Here is an example of the performance without this change:

``` r
poly <- sf::st_as_sfc("POLYGON((0 0,0.5 0,0.5 0.5,0.5 0,1 0,1 1,0 1,0 0))")
  polys <- rep(poly, 100000)
  bench::mark(
    lwgeom::st_astext(polys)
  )
#> Linking to GEOS 3.9.1, GDAL 3.2.1, PROJ 7.2.1
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression                    min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>               <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 lwgeom::st_astext(polys)    1.33m    1.33m    0.0125    37.3GB     3.17
```

<sup>Created on 2021-09-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

Here is the performance with this change:

``` r
  devtools::load_all()
#> i Loading lwgeom
#> Linking to liblwgeom 3.0.0beta1 r16016, GEOS 3.9.1, PROJ 7.2.1
  poly <- sf::st_as_sfc("POLYGON((0 0,0.5 0,0.5 0.5,0.5 0,1 0,1 1,0 1,0 0))")
  polys <- rep(poly, 100000)
  bench::mark(
    lwgeom::st_astext(polys)
  )
#> Linking to GEOS 3.9.1, GDAL 3.2.1, PROJ 7.2.1
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 x 6
#>   expression                    min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>               <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 lwgeom::st_astext(polys)    935ms    935ms      1.07    23.7MB     1.07
```

<sup>Created on 2021-09-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>
