### PR TITLE
fix st_split() #94

### DIFF
--- a/R/split.R
+++ b/R/split.R
@@ -19,12 +19,13 @@ st_split.sfg = function(x, y) {
 
 #' @export
 st_split.sfc = function(x, y) {
+  y = st_geometry(y)
     if (length(y) > 1) y = sf::st_combine(y)
 	if (inherits(x, "sfc_POLYGON") || inherits(x, "sfc_MULTIPOLYGON"))
     	stopifnot(inherits(y, "sfc_LINESTRING") || inherits(y, "sfc_MULTILINESTRING"))
 	else
 		stopifnot(inherits(x, "sfc_LINESTRING") || inherits(x, "sfc_MULTILINESTRING"))
-    st_sfc(CPL_split(x, st_geometry(y)), crs = st_crs(x))
+    st_sfc(CPL_split(x, y), crs = st_crs(x))
 }
 
 #' @export

--- a/tests/testthat/test_lwgeom.R
+++ b/tests/testthat/test_lwgeom.R
@@ -130,3 +130,26 @@ test_that("st_wrap_x works", {
   expect_equal(st_bbox(x)$xmin, splitline, check.attributes = FALSE)
   expect_equal(st_bbox(x)$xmax, splitline + offset, check.attributes = FALSE)
 })
+
+test_that("st_split works", {
+  library(lwgeom)
+  library(sf)
+  
+  l = st_as_sfc('MULTILINESTRING((10 10, 190 10, 190 190), (15 15, 30 30, 100 90))')
+  
+  pts = st_sfc(st_multipoint(matrix(c(30, 30,
+                                      190, 10),
+                                    ncol = 2,
+                                    byrow = TRUE)))
+  pts = st_cast(pts, "POINT")
+  pts_sf = st_sf(pts)
+  
+  splitted1 = st_split(l, pts)
+  splitted1 = st_collection_extract(splitted1, "LINESTRING")
+  
+  splitted2 = st_split(l, pts_sf)
+  splitted2 = st_collection_extract(splitted2, "LINESTRING")
+  
+  expect_equal(length(splitted1), 4)
+  expect_equal(splitted1, splitted2)
+})


### PR DESCRIPTION
Fix #94.
I pre-converted `y` to sfc so that `length(y)` works properly in `st_split.sfc()`.